### PR TITLE
Update FreeDesktopPlatform 21.08 -> 23.08

### DIFF
--- a/com.github._0negal.Viper.yaml
+++ b/com.github._0negal.Viper.yaml
@@ -1,8 +1,8 @@
 app-id: com.github._0negal.Viper
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '23.08'
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: viper-run
 separate-locales: false


### PR DESCRIPTION
Update outdated and EOL version of the FreeDesktopPlatform. Fixes https://github.com/flathub/com.github._0negal.Viper/issues/20.